### PR TITLE
Stack too deep for approval module

### DIFF
--- a/src/AgoraGovernor.sol
+++ b/src/AgoraGovernor.sol
@@ -425,14 +425,16 @@ contract AgoraGovernor is
         public
         virtual
     {
-        for (uint8 i = 0; i < calldatas.length; i++) {
-            bytes24 scopeKey = ScopeKey._pack(targets[i], bytes4(calldatas[i]));
+        unchecked {
+            for (uint8 i; i < calldatas.length; i++) {
+                bytes24 scopeKey = ScopeKey._pack(targets[i], bytes4(calldatas[i]));
 
-            if (PROPOSAL_TYPES_CONFIGURATOR.assignedScopes(proposalType, scopeKey).exists) {
-                PROPOSAL_TYPES_CONFIGURATOR.validateProposedTx(calldatas[i], proposalType, scopeKey);
-            } else {
-                if (PROPOSAL_TYPES_CONFIGURATOR.scopeExists(scopeKey)) {
-                    revert InvalidProposedTxForType();
+                if (PROPOSAL_TYPES_CONFIGURATOR.assignedScopes(proposalType, scopeKey).exists) {
+                    PROPOSAL_TYPES_CONFIGURATOR.validateProposedTx(calldatas[i], proposalType, scopeKey);
+                } else {
+                    if (PROPOSAL_TYPES_CONFIGURATOR.scopeExists(scopeKey)) {
+                        revert InvalidProposedTxForType();
+                    }
                 }
             }
         }
@@ -555,7 +557,7 @@ contract AgoraGovernor is
         proposal.votingModule = address(module);
         proposal.proposalType = proposalType;
 
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, proposalType);
 
         emit ProposalCreated(
             proposalId, _msgSender(), address(module), proposalData, snapshot, deadline, description, proposalType

--- a/src/ProposalTypesConfigurator.sol
+++ b/src/ProposalTypesConfigurator.sol
@@ -24,8 +24,8 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
 
     mapping(uint8 proposalTypeId => ProposalType) internal _proposalTypes;
     mapping(uint8 proposalTypeId => bool) internal _proposalTypesExists;
-    mapping(uint8 proposalTypeId => mapping(bytes24 key => Scope)) public _assignedScopes;
-    Scope[] public _scopes;
+    mapping(uint8 proposalTypeId => mapping(bytes24 key => Scope)) internal _assignedScopes;
+    Scope[] internal _scopes;
 
     /*//////////////////////////////////////////////////////////////
                                MODIFIERS

--- a/src/ProposalTypesConfigurator.sol
+++ b/src/ProposalTypesConfigurator.sol
@@ -25,6 +25,7 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
     mapping(uint8 proposalTypeId => ProposalType) internal _proposalTypes;
     mapping(uint8 proposalTypeId => bool) internal _proposalTypesExists;
     mapping(uint8 proposalTypeId => mapping(bytes24 key => Scope)) internal _assignedScopes;
+    mapping(bytes24 key => bool) internal _scopeExists;
     Scope[] internal _scopes;
 
     /*//////////////////////////////////////////////////////////////
@@ -89,8 +90,8 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
      * @notice Gets the list of all scopes.
      * @return scopes List of all the Scope structs defined.
      */
-    function scopes() external view override returns (Scope[] memory) {
-        return _scopes;
+    function scopeExists(bytes24 key) external view override returns (bool) {
+        return _scopeExists[key];
     }
 
     /**
@@ -122,6 +123,7 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
         _scopes.push(scope);
 
         _assignedScopes[proposalTypeId][key] = scope;
+        _scopeExists[key] = true;
         _proposalTypes[proposalTypeId].validScopes.push(key);
     }
 

--- a/src/interfaces/IAgoraGovernor.sol
+++ b/src/interfaces/IAgoraGovernor.sol
@@ -20,4 +20,8 @@ abstract contract IAgoraGovernor is IGovernor {
         view
         virtual
         returns (uint256 againstVotes, uint256 forVotes, uint256 abstainVotes);
+
+    function validateProposalData(address[] memory targets, bytes[] memory calldatas, uint8 proposalType)
+        external
+        virtual;
 }

--- a/src/interfaces/IProposalTypesConfigurator.sol
+++ b/src/interfaces/IProposalTypesConfigurator.sol
@@ -71,7 +71,7 @@ interface IProposalTypesConfigurator {
 
     function proposalTypes(uint8 proposalTypeId) external view returns (ProposalType memory);
     function assignedScopes(uint8 proposalTypeId, bytes24 scopeKey) external view returns (Scope memory);
-    function scopes() external view returns (Scope[] memory);
+    function scopeExists(bytes24 key) external view returns (bool);
 
     function setProposalType(
         uint8 proposalTypeId,

--- a/src/modules/ApprovalVotingModule.sol
+++ b/src/modules/ApprovalVotingModule.sol
@@ -91,7 +91,7 @@ contract ApprovalVotingModule is VotingModule {
      * @param proposalId The id of the proposal.
      * @param proposalData The proposal data encoded as `PROPOSAL_DATA_ENCODING`.
      */
-    function propose(uint256 proposalId, bytes memory proposalData, bytes32 descriptionHash) external override {
+    function propose(uint256 proposalId, bytes memory proposalData, bytes32 descriptionHash, uint8 proposalTypeId) external override {
         _onlyGovernor();
         if (proposalId != uint256(keccak256(abi.encode(msg.sender, address(this), proposalData, descriptionHash)))) {
             revert WrongProposalId();
@@ -114,6 +114,7 @@ contract ApprovalVotingModule is VotingModule {
             }
         }
 
+        IAgoraGovernor governor = IAgoraGovernor(proposals[proposalId].governor);
         unchecked {
             // Ensure proposal params of each option have the same length between themselves
             ProposalOption memory option;
@@ -123,6 +124,7 @@ contract ApprovalVotingModule is VotingModule {
                     revert InvalidParams();
                 }
 
+                governor.validateProposalData(option.targets, option.calldatas, proposalTypeId);
                 proposals[proposalId].options.push(option);
             }
         }

--- a/src/modules/OptimisticModule.sol
+++ b/src/modules/OptimisticModule.sol
@@ -59,7 +59,7 @@ contract OptimisticModule_SocialSignalling is VotingModule {
      * @param proposalId The id of the proposal.
      * @param proposalData The proposal data encoded as `PROPOSAL_DATA_ENCODING`.
      */
-    function propose(uint256 proposalId, bytes memory proposalData, bytes32 descriptionHash) external override {
+    function propose(uint256 proposalId, bytes memory proposalData, bytes32 descriptionHash, uint8 proposalTypeId) external override {
         _onlyGovernor();
         if (proposalId != uint256(keccak256(abi.encode(msg.sender, address(this), proposalData, descriptionHash)))) {
             revert WrongProposalId();
@@ -71,7 +71,6 @@ contract OptimisticModule_SocialSignalling is VotingModule {
 
         ProposalSettings memory proposalSettings = abi.decode(proposalData, (ProposalSettings));
 
-        uint8 proposalTypeId = IAgoraGovernor(msg.sender).getProposalType(proposalId);
         IProposalTypesConfigurator proposalConfigurator =
             IProposalTypesConfigurator(IAgoraGovernor(msg.sender).PROPOSAL_TYPES_CONFIGURATOR());
         IProposalTypesConfigurator.ProposalType memory proposalType = proposalConfigurator.proposalTypes(proposalTypeId);

--- a/src/modules/VotingModule.sol
+++ b/src/modules/VotingModule.sol
@@ -37,7 +37,7 @@ abstract contract VotingModule {
                             WRITE FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    function propose(uint256 proposalId, bytes memory proposalData, bytes32 descriptionHash) external virtual;
+    function propose(uint256 proposalId, bytes memory proposalData, bytes32 descriptionHash, uint8 proposalTypeId) external virtual;
 
     function _countVote(uint256 proposalId, address account, uint8 support, uint256 weight, bytes memory params)
         external

--- a/test/ApprovalVotingModule.t.sol
+++ b/test/ApprovalVotingModule.t.sol
@@ -61,7 +61,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.prank(governor);
         uint256 proposalId = hashProposalWithModule(governor, address(module), proposalData, descriptionHash);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         Proposal memory proposal = module._proposals(proposalId);
 
@@ -93,7 +93,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.startPrank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](1);
         votes[0] = 0;
@@ -117,7 +117,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.startPrank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 0;
@@ -142,7 +142,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.startPrank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 0;
@@ -167,7 +167,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.startPrank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 0;
@@ -192,7 +192,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.startPrank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](1);
         bytes memory params = abi.encode(votes);
@@ -285,7 +285,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.startPrank(governor);
         uint256 proposalId = hashProposalWithModule(governor, address(module), proposalData, descriptionHash);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 1;
@@ -325,7 +325,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.startPrank(governor);
         uint256 proposalId = hashProposalWithModule(governor, address(module), proposalData, descriptionHash);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 0;
@@ -358,7 +358,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.startPrank(governor);
         uint256 proposalId = hashProposalWithModule(governor, address(module), proposalData, descriptionHash);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 1;
@@ -398,7 +398,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.startPrank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 0;
@@ -419,11 +419,11 @@ contract ApprovalVotingModuleTest is Test {
         (bytes memory proposalData,,) = _formatProposalData();
         uint256 proposalId = hashProposalWithModule(governor, address(module), proposalData, descriptionHash);
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         vm.expectRevert(VotingModule.ExistingProposal.selector);
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
     }
 
     function testRevert_propose_invalidProposalData() public {
@@ -432,7 +432,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.expectRevert();
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
     }
 
     function testRevert_propose_invalidParams_noOptions() public {
@@ -450,7 +450,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.expectRevert(VotingModule.InvalidParams.selector);
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
     }
 
     function testRevert_propose_invalidParams_lengthMismatch() public {
@@ -472,7 +472,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.expectRevert(VotingModule.InvalidParams.selector);
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
     }
 
     function testRevert_propose_maxChoicesExceeded() public {
@@ -490,7 +490,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.expectRevert(ApprovalVotingModule.MaxChoicesExceeded.selector);
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
     }
 
     function testRevert_propose_invalidCastVoteData() public {
@@ -499,7 +499,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         bytes memory params = abi.encode(0x12345678);
 
@@ -514,7 +514,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.expectRevert(ApprovalVotingModule.WrongProposalId.selector);
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
     }
 
     function testRevert_countVote_onlyGovernor() public {
@@ -523,7 +523,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.prank(governor);
         uint256 proposalId = hashProposalWithModule(governor, address(module), proposalData, descriptionHash);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         vm.expectRevert(VotingModule.NotGovernor.selector);
         module._countVote(proposalId, voter, uint8(VoteType.Abstain), weight, "");
@@ -535,7 +535,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](0);
         bytes memory params = abi.encode(votes);
@@ -551,7 +551,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](3);
         votes[0] = 0;
@@ -570,7 +570,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.prank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 1;
@@ -588,7 +588,7 @@ contract ApprovalVotingModuleTest is Test {
         uint256 weight = 100;
 
         vm.startPrank(governor);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         uint256[] memory votes = new uint256[](2);
         votes[0] = 2;
@@ -604,7 +604,7 @@ contract ApprovalVotingModuleTest is Test {
 
         vm.prank(governor);
         uint256 proposalId = hashProposalWithModule(governor, address(module), proposalData, descriptionHash);
-        module.propose(proposalId, proposalData, descriptionHash);
+        module.propose(proposalId, proposalData, descriptionHash, 0);
 
         vm.expectRevert(VotingModule.NotGovernor.selector);
         module._formatExecuteParams(proposalId, proposalData);

--- a/test/ProposalTypesConfigurator.t.sol
+++ b/test/ProposalTypesConfigurator.t.sol
@@ -129,7 +129,6 @@ contract SetProposalType is ProposalTypesConfiguratorTest {
         assertEq(propType.approvalThreshold, 6_000);
         assertEq(propType.name, "New Default");
         assertEq(propType.description, "Lorem Ipsum");
-        // assertEq(propType.validScopes, scopes);
 
         vm.prank(_adminOrTimelock(_actorSeed));
         proposalTypesConfigurator.setProposalType(1, 0, 0, "Optimistic", "Lorem Ipsum", address(0), scopes);
@@ -138,7 +137,6 @@ contract SetProposalType is ProposalTypesConfiguratorTest {
         assertEq(propType.approvalThreshold, 0);
         assertEq(propType.name, "Optimistic");
         assertEq(propType.description, "Lorem Ipsum");
-        // assertEq(propType.validScopes, scopes);
     }
 
     function testFuzz_SetScopeForProposalType(uint256 _actorSeed) public {


### PR DESCRIPTION
This is just an example of getting `EVM Revert` on testing suite when adding the scope validation to the approval module. Not sure the best way to handle this, we should look for more gas savings or disable the logic for now. 