### PR TITLE
Allow multiple scopes for proposal type

### DIFF
--- a/src/ProposalTypesConfigurator.sol
+++ b/src/ProposalTypesConfigurator.sol
@@ -110,7 +110,7 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
         if (!_proposalTypesExists[proposalTypeId]) revert InvalidProposalType();
         if (parameters.length != comparators.length) revert InvalidParameterConditions();
 
-        Scope memory scope = Scope(key, encodedLimit, parameters, comparators, proposalTypeId, true);
+        Scope memory scope = Scope(key, encodedLimit, parameters, comparators, proposalTypeId);
 
         _assignedScopes[proposalTypeId][key].push(scope);
         _scopeExists[key] = true;
@@ -242,7 +242,7 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
      * @param calldatas The list of proposed transaction calldata.
      * @param proposalType The type of the proposal.
      */
-    function validateProposalData(address[] memory targets, bytes[] calldata calldatas, uint8 proposalType) public {
+    function validateProposalData(address[] memory targets, bytes[] calldata calldatas, uint8 proposalType) public view {
         for (uint8 i = 0; i < calldatas.length; i++) {
             bytes24 scopeKey = _pack(targets[i], bytes4(calldatas[i]));
 

--- a/src/ProposalTypesConfigurator.sol
+++ b/src/ProposalTypesConfigurator.sol
@@ -27,7 +27,7 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
 
     mapping(uint8 proposalTypeId => ProposalType) internal _proposalTypes;
     mapping(uint8 proposalTypeId => bool) internal _proposalTypesExists;
-    mapping(uint8 proposalTypeId => mapping(bytes24 key => Scope)) internal _assignedScopes;
+    mapping(uint8 proposalTypeId => mapping(bytes24 key => Scope[])) internal _assignedScopes;
     mapping(bytes24 key => bool) internal _scopeExists;
 
     /*//////////////////////////////////////////////////////////////
@@ -79,7 +79,7 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
      * @param scopeKey The function selector + contract address that is the key for a scope.
      * @return Scope struct of the scope.
      */
-    function assignedScopes(uint8 proposalTypeId, bytes24 scopeKey) external view returns (Scope memory) {
+    function assignedScopes(uint8 proposalTypeId, bytes24 scopeKey) external view returns (Scope[] memory) {
         return _assignedScopes[proposalTypeId][scopeKey];
     }
 
@@ -109,17 +109,10 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
     ) external override onlyAdminOrTimelock {
         if (!_proposalTypesExists[proposalTypeId]) revert InvalidProposalType();
         if (parameters.length != comparators.length) revert InvalidParameterConditions();
-        if (_assignedScopes[proposalTypeId][key].exists) revert NoDuplicateTxTypes(); // Do not allow multiple scopes for a single transaction type
-
-        for (uint8 i = 0; i < _proposalTypes[proposalTypeId].validScopes.length; i++) {
-            if (_proposalTypes[proposalTypeId].validScopes[i] == key) {
-                revert NoDuplicateTxTypes();
-            }
-        }
 
         Scope memory scope = Scope(key, encodedLimit, parameters, comparators, proposalTypeId, true);
 
-        _assignedScopes[proposalTypeId][key] = scope;
+        _assignedScopes[proposalTypeId][key].push(scope);
         _scopeExists[key] = true;
         _proposalTypes[proposalTypeId].validScopes.push(key);
 
@@ -179,30 +172,11 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
         if (!_proposalTypesExists[proposalTypeId]) revert InvalidProposalType();
         if (scope.parameters.length != scope.comparators.length) revert InvalidParameterConditions();
         bytes24 scopeKey = scope.key;
-        if (_assignedScopes[proposalTypeId][scopeKey].exists) revert NoDuplicateTxTypes(); // Do not allow multiple scopes for a single transaction type
-
-        for (uint8 i = 0; i < _proposalTypes[proposalTypeId].validScopes.length; i++) {
-            if (_proposalTypes[proposalTypeId].validScopes[i] == scopeKey) {
-                revert NoDuplicateTxTypes();
-            }
-        }
 
         _scopeExists[scopeKey] = true;
         _proposalTypes[proposalTypeId].validScopes.push(scopeKey);
-        _assignedScopes[proposalTypeId][scopeKey] = scope;
+        _assignedScopes[proposalTypeId][scopeKey].push(scope);
         emit ScopeCreated(proposalTypeId, scopeKey, scope.encodedLimits);
-    }
-
-    /**
-     * @notice Retrives the encoded limit of a transaction type signature for a given proposal type.
-     * @param proposalTypeId Id of the proposal type
-     * @param key A type signature of a function and contract address that has a limit specified in a scope
-     */
-    function getLimit(uint8 proposalTypeId, bytes24 key) public view returns (bytes memory encodedLimits) {
-        if (!_proposalTypesExists[proposalTypeId]) revert InvalidProposalType();
-        if (!_assignedScopes[proposalTypeId][key].exists) revert InvalidScope();
-        Scope memory validScope = _assignedScopes[proposalTypeId][key];
-        return validScope.encodedLimits;
     }
 
     /**
@@ -230,31 +204,34 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
      * @param key A type signature of a function and contract address that has a limit specified in a scope
      */
     function validateProposedTx(bytes calldata proposedTx, uint8 proposalTypeId, bytes24 key) public view {
-        Scope memory validScope = _assignedScopes[proposalTypeId][key];
-        bytes memory scopeLimit = validScope.encodedLimits;
-        bytes4 selector = bytes4(scopeLimit);
-        if (selector != bytes4(proposedTx[:4])) revert Invalid4ByteSelector();
+        Scope[] memory assignedScopes = _assignedScopes[proposalTypeId][key];
+        for (uint8 i = 0; i < assignedScopes.length; i++) {
+            Scope memory validScope = assignedScopes[i];
+            bytes memory scopeLimit = validScope.encodedLimits;
+            bytes4 selector = bytes4(scopeLimit);
+            if (selector != bytes4(proposedTx[:4])) revert Invalid4ByteSelector();
 
-        uint256 startIdx = 4;
-        uint256 endIdx = startIdx;
-        for (uint8 i = 0; i < validScope.parameters.length; i++) {
-            endIdx = endIdx + validScope.parameters[i].length;
+            uint256 startIdx = 4;
+            uint256 endIdx = startIdx;
+            for (uint8 j = 0; j < validScope.parameters.length; j++) {
+                endIdx = endIdx + validScope.parameters[j].length;
 
-            bytes32 param = bytes32(proposedTx[startIdx:endIdx]);
-            if (validScope.comparators[i] == Comparators.EQUAL) {
-                bytes32 scopedParam = bytes32(this.getParameter(scopeLimit, startIdx, endIdx));
-                if (scopedParam != param) revert InvalidParamNotEqual();
+                bytes32 param = bytes32(proposedTx[startIdx:endIdx]);
+                if (validScope.comparators[j] == Comparators.EQUAL) {
+                    bytes32 scopedParam = bytes32(this.getParameter(scopeLimit, startIdx, endIdx));
+                    if (scopedParam != param) revert InvalidParamNotEqual();
+                }
+
+                if (validScope.comparators[j] == Comparators.LESS_THAN) {
+                    if (param >= bytes32(validScope.parameters[j])) revert InvalidParamRange();
+                }
+
+                if (validScope.comparators[j] == Comparators.GREATER_THAN) {
+                    if (param <= bytes32(validScope.parameters[j])) revert InvalidParamRange();
+                }
+
+                startIdx = endIdx;
             }
-
-            if (validScope.comparators[i] == Comparators.LESS_THAN) {
-                if (param >= bytes32(validScope.parameters[i])) revert InvalidParamRange();
-            }
-
-            if (validScope.comparators[i] == Comparators.GREATER_THAN) {
-                if (param <= bytes32(validScope.parameters[i])) revert InvalidParamRange();
-            }
-
-            startIdx = endIdx;
         }
     }
 
@@ -269,7 +246,7 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
         for (uint8 i = 0; i < calldatas.length; i++) {
             bytes24 scopeKey = _pack(targets[i], bytes4(calldatas[i]));
 
-            if (_assignedScopes[proposalType][scopeKey].exists) {
+            if (_assignedScopes[proposalType][scopeKey].length != 0) {
                 validateProposedTx(calldatas[i], proposalType, scopeKey);
             } else {
                 if (_scopeExists[scopeKey]) {

--- a/src/ProposalTypesConfigurator.sol
+++ b/src/ProposalTypesConfigurator.sol
@@ -204,9 +204,9 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
      * @param key A type signature of a function and contract address that has a limit specified in a scope
      */
     function validateProposedTx(bytes calldata proposedTx, uint8 proposalTypeId, bytes24 key) public view {
-        Scope[] memory assignedScopes = _assignedScopes[proposalTypeId][key];
-        for (uint8 i = 0; i < assignedScopes.length; i++) {
-            Scope memory validScope = assignedScopes[i];
+        Scope[] memory scopes = _assignedScopes[proposalTypeId][key];
+        for (uint8 i = 0; i < scopes.length; i++) {
+            Scope memory validScope = scopes[i];
             bytes memory scopeLimit = validScope.encodedLimits;
             bytes4 selector = bytes4(scopeLimit);
             if (selector != bytes4(proposedTx[:4])) revert Invalid4ByteSelector();

--- a/src/ProposalTypesConfigurator.sol
+++ b/src/ProposalTypesConfigurator.sol
@@ -242,7 +242,10 @@ contract ProposalTypesConfigurator is IProposalTypesConfigurator {
      * @param calldatas The list of proposed transaction calldata.
      * @param proposalType The type of the proposal.
      */
-    function validateProposalData(address[] memory targets, bytes[] calldata calldatas, uint8 proposalType) public view {
+    function validateProposalData(address[] memory targets, bytes[] calldata calldatas, uint8 proposalType)
+        public
+        view
+    {
         for (uint8 i = 0; i < calldatas.length; i++) {
             bytes24 scopeKey = _pack(targets[i], bytes4(calldatas[i]));
 

--- a/src/interfaces/IProposalTypesConfigurator.sol
+++ b/src/interfaces/IProposalTypesConfigurator.sol
@@ -58,7 +58,6 @@ interface IProposalTypesConfigurator {
         bytes[] parameters;
         Comparators[] comparators;
         uint8 proposalTypeId;
-        bool exists;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IProposalTypesConfigurator.sol
+++ b/src/interfaces/IProposalTypesConfigurator.sol
@@ -69,7 +69,7 @@ interface IProposalTypesConfigurator {
     function initialize(address _governor, ProposalType[] calldata _proposalTypes) external;
 
     function proposalTypes(uint8 proposalTypeId) external view returns (ProposalType memory);
-    function assignedScopes(uint8 proposalTypeId, bytes24 scopeKey) external view returns (Scope memory);
+    function assignedScopes(uint8 proposalTypeId, bytes24 scopeKey) external view returns (Scope[] memory);
     function scopeExists(bytes24 key) external view returns (bool);
 
     function setProposalType(
@@ -91,7 +91,6 @@ interface IProposalTypesConfigurator {
     ) external;
 
     function addScopeForProposalType(uint8 proposalTypeId, Scope calldata scope) external;
-    function getLimit(uint8 proposalTypeId, bytes24 key) external returns (bytes memory);
     function validateProposedTx(bytes calldata proposedTx, uint8 proposalTypeId, bytes24 key) external;
     function validateProposalData(address[] memory targets, bytes[] memory calldatas, uint8 proposalType) external;
 }

--- a/src/interfaces/IProposalTypesConfigurator.sol
+++ b/src/interfaces/IProposalTypesConfigurator.sol
@@ -10,7 +10,6 @@ interface IProposalTypesConfigurator {
     error InvalidApprovalThreshold();
     error InvalidProposalType();
     error InvalidParameterConditions();
-    error NoDuplicateTxTypes();
     error InvalidScope();
     error NotAdminOrTimelock();
     error NotAdmin();

--- a/test/ProposalTypesConfigurator.t.sol
+++ b/test/ProposalTypesConfigurator.t.sol
@@ -201,9 +201,6 @@ contract SetProposalType is ProposalTypesConfiguratorTest {
         proposalTypesConfigurator.setScopeForProposalType(0, scopeKey, txEncoded, parameters, comparators);
 
         vm.stopPrank();
-
-        bytes memory limit = proposalTypesConfigurator.getLimit(0, scopeKey);
-        assertEq(limit, txEncoded);
     }
 
     function test_RevertIf_NotAdminOrTimelock(address _actor) public {
@@ -261,23 +258,6 @@ contract SetProposalType is ProposalTypesConfiguratorTest {
         );
         vm.stopPrank();
     }
-
-    function testRevert_setScopeForProposalType_NoDuplicateTxTypes() public {
-        vm.startPrank(admin);
-        bytes32 txTypeHash = keccak256("transfer(address,address,uint)");
-        bytes memory txEncoded = abi.encode("transfer(address,address,uint)", 0xdeadbeef, 0xdeadbeef, 10);
-        address contractAddress = makeAddr("contract");
-        bytes24 scopeKey = _pack(contractAddress, bytes4(txTypeHash));
-        proposalTypesConfigurator.setScopeForProposalType(
-            0, scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1)
-        );
-
-        vm.expectRevert(IProposalTypesConfigurator.NoDuplicateTxTypes.selector);
-        proposalTypesConfigurator.setScopeForProposalType(
-            0, scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1)
-        );
-        vm.stopPrank();
-    }
 }
 
 contract AddScopeForProposalType is ProposalTypesConfiguratorTest {
@@ -309,11 +289,6 @@ contract AddScopeForProposalType is ProposalTypesConfiguratorTest {
         emit ScopeCreated(0, scope.key, scope.encodedLimits);
         proposalTypesConfigurator.addScopeForProposalType(0, scope);
         vm.stopPrank();
-
-        bytes memory limit1 = proposalTypesConfigurator.getLimit(0, scopeKey1);
-        bytes memory limit2 = proposalTypesConfigurator.getLimit(0, scopeKey2);
-        assertEq(limit1, txEncoded1);
-        assertEq(limit2, txEncoded2);
     }
 
     function testRevert_addScopeForProposalType_InvalidProposalType() public {
@@ -331,25 +306,6 @@ contract AddScopeForProposalType is ProposalTypesConfiguratorTest {
         vm.stopPrank();
     }
 
-    function testRevert_addScopeForProposalType_NoDuplicateTxTypes() public {
-        vm.startPrank(admin);
-        bytes32 txTypeHash = keccak256("transfer(address,address,uint)");
-        address contractAddress = makeAddr("contract");
-        bytes24 scopeKey = _pack(contractAddress, bytes4(txTypeHash));
-        bytes memory txEncoded = abi.encode("transfer(address,address,uint)", 0xdeadbeef, 0xdeadbeef, 10);
-
-        proposalTypesConfigurator.setScopeForProposalType(
-            0, scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1)
-        );
-
-        vm.expectRevert(IProposalTypesConfigurator.NoDuplicateTxTypes.selector);
-        IProposalTypesConfigurator.Scope memory scope = IProposalTypesConfigurator.Scope(
-            scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1), 0, true
-        );
-        proposalTypesConfigurator.addScopeForProposalType(0, scope);
-        vm.stopPrank();
-    }
-
     function testRevert_addScopeForProposalType_InvalidParametersCondition() public {
         vm.startPrank(admin);
         bytes32 txTypeHash = keccak256("transfer(address,address,uint)");
@@ -363,29 +319,6 @@ contract AddScopeForProposalType is ProposalTypesConfiguratorTest {
         vm.expectRevert(IProposalTypesConfigurator.InvalidParameterConditions.selector);
         proposalTypesConfigurator.addScopeForProposalType(0, scope);
         vm.stopPrank();
-    }
-}
-
-contract getLimit is ProposalTypesConfiguratorTest {
-    function testRevert_getLimit_InvalidProposalType() public {
-        vm.expectRevert(IProposalTypesConfigurator.InvalidProposalType.selector);
-        proposalTypesConfigurator.getLimit(3, bytes24(keccak256("foobar(address,address)")));
-    }
-
-    function testRevert_getLimit_InvalidScope() public {
-        vm.startPrank(admin);
-        bytes32 txTypeHash = keccak256("transfer(address,address,uint)");
-        address contractAddress = makeAddr("contract");
-        bytes24 scopeKey = _pack(contractAddress, bytes4(txTypeHash));
-        bytes memory txEncoded = abi.encode("transfer(address,address,uint)", 0xdeadbeef, 0xdeadbeef, 10);
-
-        proposalTypesConfigurator.setScopeForProposalType(
-            0, scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1)
-        );
-        vm.stopPrank();
-
-        vm.expectRevert(IProposalTypesConfigurator.InvalidScope.selector);
-        proposalTypesConfigurator.getLimit(0, bytes24(keccak256("foobar(address,address)")));
     }
 }
 

--- a/test/ProposalTypesConfigurator.t.sol
+++ b/test/ProposalTypesConfigurator.t.sol
@@ -371,6 +371,55 @@ contract ValidateProposedTx is ProposalTypesConfiguratorTest {
     }
 }
 
+contract MultipleScopeValidation is ProposalTypesConfiguratorTest {
+    function testFuzz_MultipleScopeValidationRange(uint256 _actorSeed) public {
+        vm.prank(_adminOrTimelock(_actorSeed));
+        vm.expectEmit();
+        bytes24[] memory scopes = new bytes24[](1);
+        emit ProposalTypeSet(0, 4_000, 6_000, "New Default", "Lorem Ipsum", scopes);
+        proposalTypesConfigurator.setProposalType(0, 4_000, 6_000, "New Default", "Lorem Ipsum", address(0), scopes);
+
+        vm.startPrank(admin);
+        bytes32 txTypeHash = keccak256("transfer(address,address,uint256)");
+        address contractAddress = makeAddr("contract");
+        bytes24 scopeKey = _pack(contractAddress, bytes4(txTypeHash));
+        address _from = makeAddr("from");
+        address _to = makeAddr("to");
+        bytes memory txEncoded1 = abi.encodeWithSignature("transfer(address,address,uint256)", _from, _to, uint256(10));
+
+        bytes[] memory parameters1 = new bytes[](3);
+        parameters1[0] = abi.encode(uint256(uint160(_from)));
+        parameters1[1] = abi.encode(uint256(uint160(_to)));
+        parameters1[2] = abi.encode(uint256(10));
+
+        IProposalTypesConfigurator.Comparators[] memory comparators1 = new IProposalTypesConfigurator.Comparators[](3);
+
+        comparators1[0] = IProposalTypesConfigurator.Comparators(1); // EQ
+        comparators1[1] = IProposalTypesConfigurator.Comparators(1); // EQ
+        comparators1[2] = IProposalTypesConfigurator.Comparators(3); // GREATER THAN
+
+        proposalTypesConfigurator.setScopeForProposalType(0, scopeKey, txEncoded1, parameters1, comparators1);
+
+        bytes[] memory parameters2 = new bytes[](3);
+        parameters2[0] = abi.encode(uint256(uint160(_from)));
+        parameters2[1] = abi.encode(uint256(uint160(_to)));
+        parameters2[2] = abi.encode(uint256(50));
+
+        IProposalTypesConfigurator.Comparators[] memory comparators2 = new IProposalTypesConfigurator.Comparators[](3);
+
+        comparators2[0] = IProposalTypesConfigurator.Comparators(1); // EQ
+        comparators2[1] = IProposalTypesConfigurator.Comparators(1); // EQ
+        comparators2[2] = IProposalTypesConfigurator.Comparators(2); // LESS THAN
+
+        bytes memory txEncoded2 = abi.encodeWithSignature("transfer(address,address,uint256)", _from, _to, uint256(50));
+        proposalTypesConfigurator.setScopeForProposalType(0, scopeKey, txEncoded2, parameters2, comparators2);
+
+        vm.stopPrank();
+        bytes memory proposedTx = abi.encodeWithSignature("transfer(address,address,uint256)", _from, _to, uint256(15));
+        proposalTypesConfigurator.validateProposedTx(proposedTx, 0, scopeKey);
+    }
+}
+
 contract GovernorMock {
     address immutable adminAddress;
     address immutable timelockAddress;

--- a/test/ProposalTypesConfigurator.t.sol
+++ b/test/ProposalTypesConfigurator.t.sol
@@ -283,7 +283,7 @@ contract AddScopeForProposalType is ProposalTypesConfiguratorTest {
         proposalTypesConfigurator.setScopeForProposalType(0, scopeKey1, txEncoded1, parameters, comparators);
 
         IProposalTypesConfigurator.Scope memory scope = IProposalTypesConfigurator.Scope(
-            scopeKey2, txEncoded2, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1), 0, true
+            scopeKey2, txEncoded2, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1), 0
         );
 
         emit ScopeCreated(0, scope.key, scope.encodedLimits);
@@ -300,7 +300,7 @@ contract AddScopeForProposalType is ProposalTypesConfiguratorTest {
 
         vm.expectRevert(IProposalTypesConfigurator.InvalidProposalType.selector);
         IProposalTypesConfigurator.Scope memory scope = IProposalTypesConfigurator.Scope(
-            scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1), 3, true
+            scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](1), 3
         );
         proposalTypesConfigurator.addScopeForProposalType(3, scope);
         vm.stopPrank();
@@ -314,7 +314,7 @@ contract AddScopeForProposalType is ProposalTypesConfiguratorTest {
         bytes memory txEncoded = abi.encode("transfer(address,address,uint)", 0xdeadbeef, 0xdeadbeef, 10);
 
         IProposalTypesConfigurator.Scope memory scope = IProposalTypesConfigurator.Scope(
-            scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](2), 0, true
+            scopeKey, txEncoded, new bytes[](1), new IProposalTypesConfigurator.Comparators[](2), 0
         );
         vm.expectRevert(IProposalTypesConfigurator.InvalidParameterConditions.selector);
         proposalTypesConfigurator.addScopeForProposalType(0, scope);


### PR DESCRIPTION
This adds the functionality to support multiple scopes on a single proposal type.

It retains the capability to have a default proposal type in which any unscoped transactions can still be performed. Furthermore it allows the use case:

ProposalType 1 -> token transfers: amt > 1000
ProposalType 2 -> token transfers: amt < 50

It also supports a new proposal type configuration such that:

ProposalType 3 -> token transfers:  50 > amt < 1000

If a scope is not defined for a given proposal type and one exists on another proposal type the transaction will revert.

In order to prevent this, the admin must create multiple scopes and assign them to the proposal type to include the desired behavior. Using the example above the default proposal type would need to have the configuration of ProposalType3, once ProposalType1 and ProposalType2 are created in order to have coverage of the full range of possible values.